### PR TITLE
新增 MySQL error log 和指定 port 

### DIFF
--- a/lib/openbox/database.rb
+++ b/lib/openbox/database.rb
@@ -63,7 +63,9 @@ module Openbox
     def retry_in(timeout: 30)
       Timeout.timeout(timeout) do
         yield
-      rescue StandardError
+      rescue StandardError => error
+        puts error
+        puts "retry..."
         sleep 1
         retry
       end

--- a/lib/openbox/database.rb
+++ b/lib/openbox/database.rb
@@ -52,10 +52,11 @@ module Openbox
 
       uri = URI.parse(ENV['DATABASE_URL'])
       username, password = uri.userinfo.split(':', 2)
+      port = uri.port || 3306
       connect_attrs = URI.decode_www_form(uri.query || '').to_h
       retry_in(timeout: 30) do
         Mysql2::Client.new(username: username, password: password, host: uri.host,
-                           database: uri.path[1..-1], connect_attrs: connect_attrs)
+                           database: uri.path[1..-1], port: port, connect_attrs: connect_attrs)
       end
     end
 


### PR DESCRIPTION
# 新增 MySQL error log 和指定 port 
- Add MySQL error log when connect error.
- Add specific port when Mysql2::Client connect to database.